### PR TITLE
chore(ai): omit Claude session URLs

### DIFF
--- a/ai/claude-settings.json
+++ b/ai/claude-settings.json
@@ -213,6 +213,9 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "attribution": {
+    "sessionUrl": false
+  },
   "enableAllProjectMcpServers": true,
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Summary

Add Claude Code's new `attribution.sessionUrl` setting and disable hosted session links in generated commit and PR attribution. This keeps generic Claude attribution while avoiding per-session URLs in repo history and PR text.

## Problem

Claude Code 2.1.183 added a direct setting for suppressing claude.ai session links in web and Remote Control sessions. The dotfiles config did not set it yet, so those links could be included by default.

---
Generated with [Claude Code](https://claude.com/claude-code)