### PR TITLE
Preserve Claude bash command behavior

### DIFF
--- a/ai/claude-settings.json
+++ b/ai/claude-settings.json
@@ -216,6 +216,7 @@
   "attribution": {
     "sessionUrl": false
   },
+  "respondToBashCommands": false,
   "enableAllProjectMcpServers": true,
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Summary
- Set `respondToBashCommands` to `false` in Claude settings

## Why
Claude Code 2.1.186 changed `!` bash commands so Claude responds to command output automatically by default. The changelog documents this setting as the compatibility switch for the previous context-only behavior.

## Verification
- `jq empty ai/claude-settings.json`